### PR TITLE
Bug/sersic integration

### DIFF
--- a/psfMC/ModelComponents/Sersic.py
+++ b/psfMC/ModelComponents/Sersic.py
@@ -1,6 +1,6 @@
 from __future__ import division
 from warnings import warn
-from numpy import asarray, exp, cos, sin, deg2rad, sum, log, pi, dot
+from numpy import asarray, exp, cos, sin, deg2rad, sum, log, pi, dot, abs
 from scipy.special import gamma
 from pymc import Potential
 from .ComponentBase import ComponentBase
@@ -105,8 +105,8 @@ class Sersic(ComponentBase):
         :param mag_zp: Magnitude zeropoint (e.g. magnitude of 1 count/second)
         :param coords: Optional pre-computed x,y coordfinates of each element
         """
-        # FIXME: Central pixels still have significant error compared to galfit
-        coords = kwargs['coords'] if 'coords' in kwargs else array_coords(arr)
+        coords = kwargs['coords'] if 'coords' in kwargs \
+            else array_coords(arr.shape)
         kappa = Sersic.kappa(self.index)
         flux_tot = Sersic.total_flux_adu(self.mag, mag_zp)
         sbeff = self.sb_eff_adu(mag_zp, flux_tot, kappa)
@@ -120,45 +120,30 @@ class Sersic(ComponentBase):
         # Optimization: exp(log(a)*b) is faster than a**b or pow(a,b)
         if ne is not None:
             ser_expr = 'sbeff * exp(-kappa * expm1(log(sq_radii)*radius_pow))'
-            arr += ne.evaluate(ser_expr)
+            sb = ne.evaluate(ser_expr)
         else:
-            arr += sbeff * exp(-kappa * (exp(log(sq_radii)*radius_pow) - 1))
+            sb = sbeff * exp(-kappa * (exp(log(sq_radii)*radius_pow) - 1))
+        # estimate distance of the pixel center of mass from the pixel center
+        # in units of reff
+        grad = Sersic._normed_grad(sq_radii, radius_pow, kappa)
+        # TODO: delta_r should change per-pixel based on ellipse params
+        # Find the barycenter offset from the center within a pixel-sized
+        # trapezoid having a top with the given normed gradient, units of reff.
+        delta_r = 1 / self.reff
+        bary_offset = delta_r**2 / 12 * grad
+        arr += sb * (1 + grad * bary_offset)
         return arr
 
-    def _grad_array(self, arr, mag_zp, **kwargs):
-        coords = kwargs['coords'] if 'coords' in kwargs else array_coords(arr)
-        kappa = Sersic.kappa(self.index)
-        flux_tot = Sersic.total_flux_adu(self.mag, mag_zp)
-        sbeff = self.sb_eff_adu(mag_zp, flux_tot, kappa)
-
-        sq_radii = self.coordinate_sq_radii(coords)
-        sq_radii = sq_radii.reshape(arr.shape)
-
-        # Optimization: the square root to get to radii from square radii is
-        # combined with the sersic power here
-        radius_pow = 0.5 / self.index
-        # Optimization: exp(log(a)*b) is faster than a**b or pow(a,b)
-        out_arr = sbeff * -kappa * radius_pow * sq_radii**(radius_pow - 1) * \
-                  exp(-kappa * (exp(log(sq_radii)*radius_pow) - 1))
-        return out_arr
-
-    def add_to_array_spline(self, arr, mag_zp, **kwargs):
-        coords = kwargs['coords'] if 'coords' in kwargs else array_coords(arr)
-        coords -= 0.5
-        kappa = Sersic.kappa(self.index)
-        flux_tot = Sersic.total_flux_adu(self.mag, mag_zp)
-        sbeff = self.sb_eff_adu(mag_zp, flux_tot, kappa)
-
-        sq_radii = self.coordinate_sq_radii(coords)
-        sq_radii = sq_radii.reshape(arr.shape)
-
-        # Optimization: the square root to get to radii from square radii is
-        # combined with the sersic power here
-        radius_pow = 0.5 / self.index
-        # Optimization: exp(log(a)*b) is faster than a**b or pow(a,b)
+    @staticmethod
+    def _normed_grad(sq_radii, radius_pow, kappa):
+        """
+        The normalized gradient array (normed grad * surf brightness = grad) for
+        a Sersic profile with given square radii array, radius power (0.5/n) and
+        Sersic coefficient kappa
+        """
         if ne is not None:
-            ser_expr = 'sbeff * exp(-kappa * expm1(log(sq_radii)*radius_pow))'
-            arr += ne.evaluate(ser_expr)
+            grad_expr = '-kappa * 2*radius_pow * ' \
+                        'exp(log(sq_radii)*(radius_pow - 0.5))'
+            return ne.evaluate(grad_expr)
         else:
-            arr += sbeff * exp(-kappa * (exp(log(sq_radii)*radius_pow) - 1))
-        return arr
+            return -kappa * 2*radius_pow * exp(log(sq_radii)*(radius_pow - 0.5))

--- a/psfMC/array_utils.py
+++ b/psfMC/array_utils.py
@@ -49,13 +49,14 @@ def convolve(img, fourier_kernel):
     return np.fft.ifftshift(np.fft.irfft2(np.fft.rfft2(img) * fourier_kernel))
 
 
-def array_coords(arr):
+def array_coords(shape=(1, 1)):
     """
-    Returns arr.size x 2 array of x, y coordinates for each cell in arr
+    Returns prod(shape) x 2 array of x, y coordinates for each cell in array
+    with dimensions like shape
     """
-    coords = [np.arange(arr.size) % arr.shape[1],
-              np.arange(arr.size) // arr.shape[1]]
-    return np.transpose(coords).astype(arr.dtype)
+    indexes = np.arange(np.product(shape))
+    coords = [indexes % shape[1], indexes // shape[1]]
+    return np.transpose(coords).astype('float64')
 
 
 def norm_psf(psf_data, psf_ivm):

--- a/psfMC/models.py
+++ b/psfMC/models.py
@@ -41,7 +41,7 @@ def multicomponent_model(obs_data, obs_ivm, psf_data, psf_ivm,
     psf_select = PSFSelector(psf_list, var_list, filenames=psf_data)
 
     # pre-compute data x,y coordinates
-    data_coords = array_coords(obs_data)
+    data_coords = array_coords(obs_data.shape)
 
     model_comps = []
     stochastics = []

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -53,7 +53,7 @@ def test_sersic(index=4):
     r_min = r_maj*gfhdr['1_AR']
 
     mcmodel = np.zeros_like(gfmodel)
-    coords = array_coords(mcmodel)
+    coords = array_coords(mcmodel.shape)
     ser = Sersic(xy=(gfhdr['1_XC']-1, gfhdr['1_YC']-1),
                  mag=gfhdr['1_MAG'], index=gfhdr['1_N'],
                  reff=r_maj, reff_b=r_min,
@@ -62,8 +62,6 @@ def test_sersic(index=4):
 
     radii = np.sqrt(ser.coordinate_sq_radii(coords))
     radii = radii.reshape(mcmodel.shape)
-
-    #sbeff = ser.sb_eff_adu(mag_zp=gfhdr['MAGZPT'])
 
     print 'Commanded magnitude: {:0.2f} n={:0.1f}'.format(
         gfhdr['1_MAG'], index)


### PR DESCRIPTION
Improved per-pixel integral estimates for Sersic surface brightness profile, by calculating the gradient and using it to estimate the error resulting from just using the values at the pixel centers. Now calculate the estimated barycenter for each pixel and use the SB value for it. Per-pixel fractional error is now a maximum of ~2%, occurring in the central 4 pixels. Outside that region, fractional error is smaller.
